### PR TITLE
Fix model multiple choice preference to react correctly to deletion handler

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributors
 * [@swalladge](https://github.com/swalladge)
 * [@rvignesh89](https://github.com/rvignesh89)
 * [@okolimar](https://github.com/okolimar)
+* [@hansegucker](https://github.com/hansegucker)

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -230,8 +230,12 @@ class ModelMultipleSerializer(ModelSerializer):
     def to_db(self, value, **kwargs):
         if not value:
             return
-
-        value = list(value.values_list('pk', flat=True))
+        if hasattr(value, "pk"):
+            # Support single instances in this serializer to allow
+            # create_deletion_handler to work for model multiple choice preferences
+            value = [value.pk]
+        else:
+            value = list(value.values_list('pk', flat=True))
 
         if self.sort:
             value = sorted(value)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -250,3 +250,9 @@ class TestModelSerializers(TestCase):
         pks = s.separator.join(map(str, sorted(list(blog_entries.values_list('pk', flat=True)))))
 
         self.assertEqual(list(s.deserialize(pks)), list(blog_entries))
+
+    def test_model_multiple_single_serialization(self):
+        s = serializers.ModelMultipleSerializer(BlogEntry)
+        blog_entry = BlogEntry.objects.all().first()
+
+        self.assertEqual(s.serialize(blog_entry), s.separator.join(map(str, [blog_entry.pk])))


### PR DESCRIPTION
If you delete an object whose model is also used for a model multiple choice preference, it will cause some trouble because the preference uses `create_deletion_handler` to create a handler for the delete signal of this model. For a normal model choice field that works perfectly, but not for a model multiple choice field: The serializer only supports querysets and not single objects as provided through the signal handler.
