### PR TITLE
Use default django cache timeoout

### DIFF
--- a/dynamic_preferences/managers.py
+++ b/dynamic_preferences/managers.py
@@ -109,7 +109,7 @@ class PreferencesManager(Mapping):
             # resulting in more DB queries, so we cache an arbitrary value
             # to ensure the cache is hot (even with empty values)
             value = preferences_settings.CACHE_NONE_VALUE
-        self.cache.set(key, value, None)
+        self.cache.set(key, value)
 
     def pref_obj(self, section, name):
         return self.registry.get(section=section, name=name)


### PR DESCRIPTION
At the moment django-dynamic-preferences caches values indefinitely if caching is used. I described the reasons why it could be suboptimal in [this ticket](https://github.com/agateblue/django-dynamic-preferences/issues/247). This PR makes `django-dynamic-preferences` to use the default Django cache timeout which can be set in settings.