### PR TITLE
Allow to skip preference creation when checkpreferences is invoked

### DIFF
--- a/tests/test_checkpreferences_command.py
+++ b/tests/test_checkpreferences_command.py
@@ -33,3 +33,12 @@ class TestCheckPreferencesCommand(BaseTest, TestCase):
             "Creating missing preferences for User model...",
         ])
         self.assertEqual(out, expected_output)
+
+    def test_skip_create(self):
+        out = self.call_command("--skip_create", verbosity=0)
+        expected_output = "\n".join([
+            "Deleted 0 global preferences",
+            "Deleted 0 GlobalPreferenceModel preferences",
+            "Deleted 0 UserPreferenceModel preferences",
+        ])
+        self.assertEqual(out, expected_output)


### PR DESCRIPTION
In some case you might not want to prefill the cache, only to cleanup
the removed preferences. Thus it would be convenient to skip the
creation steps.