### PR TITLE
Add ENABLE_GLOBAL_MODEL_AUTO_REGISTRATION setting

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -65,6 +65,10 @@ Also, take some time to look at provided settings if you want to customize the p
             # want to change, but it's here just in case
             'SECTION_KEY_SEPARATOR': '__',
 
+            # Use this to disable auto registration of the GlobalPreferenceModel.
+            # This can be useful to register your own model in the global_preferences_registry.
+            'ENABLE_GLOBAL_MODEL_AUTO_REGISTRATION': True,
+
             # Use this to disable caching of preference. This can be useful to debug things
             'ENABLE_CACHE': True,
 

--- a/dynamic_preferences/apps.py
+++ b/dynamic_preferences/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig, apps
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from .registries import preference_models, global_preferences_registry
+from .settings import preferences_settings
 
 
 class DynamicPreferencesConfig(AppConfig):
@@ -9,10 +10,11 @@ class DynamicPreferencesConfig(AppConfig):
     verbose_name = _("Dynamic Preferences")
 
     def ready(self):
-        GlobalPreferenceModel = self.get_model('GlobalPreferenceModel')
+        if preferences_settings.ENABLE_GLOBAL_MODEL_AUTO_REGISTRATION:
+            GlobalPreferenceModel = self.get_model('GlobalPreferenceModel')
 
-        preference_models.register(
-            GlobalPreferenceModel, global_preferences_registry)
+            preference_models.register(
+                GlobalPreferenceModel, global_preferences_registry)
 
         # This will load all dynamic_preferences_registry.py files under
         # installed apps

--- a/dynamic_preferences/settings.py
+++ b/dynamic_preferences/settings.py
@@ -19,6 +19,7 @@ DEFAULTS = {
     'SECTION_KEY_SEPARATOR': '__',
     'REGISTRY_MODULE': 'dynamic_preferences_registry',
     'ADMIN_ENABLE_CHANGELIST_FORM': False,
+    'ENABLE_GLOBAL_MODEL_AUTO_REGISTRATION': True,
     'ENABLE_USER_PREFERENCES': True,
     'ENABLE_CACHE': True,
     'VALIDATE_NAMES': True,

--- a/tests/test_global_preferences.py
+++ b/tests/test_global_preferences.py
@@ -4,7 +4,9 @@ from datetime import timezone
 from decimal import Decimal
 
 from datetime import date, timedelta, datetime, time
+from django.apps import apps
 from django.test import LiveServerTestCase, TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.core.management import call_command
 from django.core.cache import caches
@@ -54,6 +56,17 @@ class TestGlobalPreferences(BaseTest, TestCase):
             u'company__OpenningTime': time(hour=8, minute=0),
             u'user__registration_allowed': False}
         self.assertDictEqual(manager.all(), expected)
+
+    def test_registry_default_preference_model(self):
+        app_config = apps.app_configs["dynamic_preferences"]
+        registry.preference_model = None
+
+        with override_settings(DYNAMIC_PREFERENCES={'ENABLE_GLOBAL_MODEL_AUTO_REGISTRATION': False}):
+            app_config.ready()
+            self.assertIs(registry.preference_model, None)
+
+        app_config.ready()
+        self.assertIs(registry.preference_model, GlobalPreferenceModel)
 
 
 class TestViews(BaseTest, LiveServerTestCase):


### PR DESCRIPTION
This is true by default, but when set to false, the
GlobalPreferenceModel isn't registered anymore when ready() is called on
the app config.

This is needed when you want to register your own model in one of your
apps (e.g. a subclass of GlobalPreferenceModel).