### PR TITLE
Fix default_app_config deprecation

### DIFF
--- a/dynamic_preferences/__init__.py
+++ b/dynamic_preferences/__init__.py
@@ -1,2 +1,6 @@
+import django
+
 __version__ = "1.12.0"
-default_app_config = "dynamic_preferences.apps.DynamicPreferencesConfig"
+
+if django.VERSION < (3, 2):
+    default_app_config = "dynamic_preferences.apps.DynamicPreferencesConfig"


### PR DESCRIPTION
Fix warnings:

```
RemovedInDjango41Warning: 'dynamic_preferences' defines default_app_config = 'dynamic_preferences.apps.DynamicPreferencesConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```