### PR TITLE
Remove warning in django 4.1 and add support for python 3.11 (#1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Dynamic-preferences allow you to register settings (a.k.a. preferences) in a dec
 
 With dynamic-preferences, you can update settings on the fly, through django's admin or custom forms, without restarting your application.
 
-The project is tested and work under Python 3.6, 3.7, 3.8 and 3.9 and with django 2.2, 3.0 and 3.1.
+The project is tested and work under Python 3.7, 3.8, 3.9 and 3.10 and with django 3.2 and 4.1.
 
 Features
 --------

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Dynamic-preferences allow you to register settings (a.k.a. preferences) in a dec
 
 With dynamic-preferences, you can update settings on the fly, through django's admin or custom forms, without restarting your application.
 
-The project is tested and work under Python 3.7, 3.8, 3.9 and 3.10 and with django 3.2 and 4.1.
+The project is tested and work under Python 3.7, 3.8, 3.9, 3.10 and 3.11 and with django 3.2 and 4.1.
 
 Features
 --------

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import decimal
 import os
 
-from datetime import date, timedelta, datetime, time
+from datetime import date, timedelta, datetime, time, timezone
 
 from django.conf import settings
 from django.core.validators import EMPTY_VALUES
@@ -15,7 +15,6 @@ from django.utils.dateparse import (
 from django.utils.duration import duration_string
 from django.utils.encoding import force_str
 from django.utils.timezone import (
-    utc,
     is_aware,
     make_aware,
     make_naive,
@@ -411,7 +410,7 @@ class DateTimeSerializer(BaseSerializer):
         if (field_timezone is not None) and not is_aware(value):
             return make_aware(value, field_timezone)
         elif (field_timezone is None) and is_aware(value):
-            return make_naive(value, utc)
+            return make_naive(value, timezone.utc)
         return value
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
 
 
 basepython =
+    py311: python3.11
     py310: python3.10
     py39: python3.9
     py38: python3.8


### PR DESCRIPTION
SInce updating to django 4.1, I've starting getting the following warning, which this PR fixes:
```
../usr/local/lib/python3.10/site-packages/dynamic_preferences/serializers.py:17
  /usr/local/lib/python3.10/site-packages/dynamic_preferences/serializers.py:17: RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated. Please update your code to use datetime.timezone.utc instead.
    from django.utils.timezone import (
```

Also I've gone ahead and added python 3.11 to the version list :)