### PR TITLE
Fix modelmultipleserializer PATCH API call, fixes #291

### DIFF
--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -251,10 +251,14 @@ class ModelMultipleSerializer(ModelSerializer):
             # Support single instances in this serializer to allow
             # create_deletion_handler to work for model multiple choice preferences
             value = [value.pk]
-        else:
+        elif hasattr(value, 'values_list'):
             value = list(value.values_list("pk", flat=True))
-
-        if self.sort:
+        elif isinstance(value, list) and len(value) > 0 and isinstance(value[0], self.model):
+            # Handle lists of model instances
+            value = [i.pk for i in value]
+        else:
+            raise ValueError(f'Cannot handle value {value} of type {type(value)}')
+        if value and self.sort:
             value = sorted(value)
 
         return self.separator.join(map(str, value))

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -335,3 +335,24 @@ def test_model_multiple_single_serialization_with_non_int_pk(blog_entries):
     blog_entry = BlogEntryWithNonIntPk.objects.all().first()
 
     assert s.serialize(blog_entry) == s.separator.join(map(str, [blog_entry.pk]))
+
+
+
+def test_model_multiple_to_db_empty(blog_entries):
+    result = serializers.ModelMultipleSerializer(BlogEntry).to_db([])
+    assert result is None
+
+
+def test_model_multiple_to_db_multiple(blog_entries):
+    entry1 = BlogEntry.objects.get(title="This is a test",)
+    entry2 = BlogEntry.objects.get(title="This is only a test",)
+    result = serializers.ModelMultipleSerializer(BlogEntry).to_db([
+        entry1,
+        entry2,
+    ])
+    assert result == f'{entry1.pk},{entry2.pk}'
+
+
+def test_model_multiple_to_db_invalid(blog_entries):
+    with pytest.raises(ValueError, match=r"Cannot handle value.* of type .*"):
+        serializers.ModelMultipleSerializer(BlogEntry).to_db('invalid')


### PR DESCRIPTION
If you make a PATCH call to a dynprefs endpoint to update a ModelMultipleChoicePreference field, it will not correctly handle the list of PKs. It will transform the value to a list of model instances, which is not handled by the field serializer, as you can see at the issue #291. 

With this patch that list of model instances is transformed to a list of their PKs.

The tests were previously failing so I'm not touching those.