### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+          - '3.11'
     steps:
 
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@
 [tox]
 envlist =
     {py37,py38,py39,py310}-django-32
-    {py38,py39,py310}-django-41
-    ; {py37,py38,py39,py310}-django-master
+    {py38,py39,py310,py311}-django-42
+    {py311}-django-main
 
 
 [testenv]
@@ -16,10 +16,10 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands = pytest --cov=dynamic_preferences {posargs}
 deps =
-    django-{32,41,master}: djangorestframework>=3.13,<4
+    django-{32,42,main}: djangorestframework>=3.13,<4
     django-32: Django>=3.2,<3.3
-    django-41: Django>=4.1,<4.2
-    django-master: https://github.com/django/django/archive/master.tar.gz
+    django-42: Django>=4.2,<5.0
+    django-main: https://github.com/django/django/archive/main.tar.gz
     -r{toxinidir}/requirements-test.txt
 
 
@@ -29,3 +29,6 @@ basepython =
     py39: python3.9
     py38: python3.8
     py37: python3.7
+
+[testenv:py311-django-main]
+ignore_outcome = true


### PR DESCRIPTION
- Added python 3.11 tests in CI
- Removed unecessary concurrency lock
- Tests under Django 4.2 (remove Django 4.1)
- Tests under Django main / python 3.11