### PR TITLE
Added ability to pickle FilePreference in Django 4.2

### DIFF
--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -275,6 +275,30 @@ class ModelMultipleSerializer(ModelSerializer):
             raise self.exception("Array {0} cannot be converted to int".format(value))
 
 
+# FieldFile also needs a model instance to save changes.
+class FakeInstance(object):
+    """
+    FieldFile needs a model instance to update when file is persisted
+    or deleted
+    """
+
+    def save(self):
+        return
+
+class FakeField(object):
+    """
+    FieldFile needs a field object to generate a filename, persist
+    and delete files, so we are effectively mocking that.
+    """
+
+    name = "noop"
+    attname = "noop"
+    max_length = 10000
+
+    def generate_filename(field, instance, name):
+        return os.path.join(self.preference.get_upload_path(), f.name)
+
+
 class PreferenceFieldFile(FieldFile):
     """
     In order to have the same API that we have with models.FileField,
@@ -285,32 +309,7 @@ class PreferenceFieldFile(FieldFile):
 
     def __init__(self, preference, storage, name):
         super(FieldFile, self).__init__(None, name)
-
-        # FieldFile also needs a model instance to save changes.
-        class FakeInstance(object):
-            """
-            FieldFile needs a model instance to update when file is persisted
-            or deleted
-            """
-
-            def save(self):
-                return
-
         self.instance = FakeInstance()
-
-        class FakeField(object):
-            """
-            FieldFile needs a field object to generate a filename, persist
-            and delete files, so we are effectively mocking that.
-            """
-
-            name = "noop"
-            attname = "noop"
-            max_length = 10000
-
-            def generate_filename(field, instance, name):
-                return os.path.join(self.preference.get_upload_path(), f.name)
-
         self.field = FakeField()
         self.storage = storage
         self._committed = True

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -311,6 +311,7 @@ class PreferenceFieldFile(FieldFile):
         super(FieldFile, self).__init__(None, name)
         self.instance = FakeInstance()
         self.field = FakeField()
+        self.field.storage = storage
         self.storage = storage
         self._committed = True
         self.preference = preference

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -285,6 +285,7 @@ class FakeInstance(object):
     def save(self):
         return
 
+
 class FakeField(object):
     """
     FieldFile needs a field object to generate a filename, persist
@@ -294,9 +295,6 @@ class FakeField(object):
     name = "noop"
     attname = "noop"
     max_length = 10000
-
-    def generate_filename(field, instance, name):
-        return os.path.join(self.preference.get_upload_path(), f.name)
 
 
 class PreferenceFieldFile(FieldFile):
@@ -483,5 +481,5 @@ class MultipleSerializer(BaseSerializer):
         while "" in ret:
             pos = ret.index("")
             val = ret[pos - 1] + cls.separator + ret[pos + 1]
-            ret = ret[0 : pos - 1] + [val] + ret[pos + 2 :]
+            ret = ret[0: pos - 1] + [val] + ret[pos + 2:]
         return ret

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,7 @@
 import os
 import decimal
+import pickle
+
 import pytest
 
 from datetime import date, timedelta, datetime, time
@@ -237,6 +239,19 @@ def test_file_preference_api_repr_returns_path(db):
 
     f = manager["blog__logo"]
     assert p.api_repr(f) == f.url
+
+
+def test_file_preference_if_pickleable(db):
+    manager = global_preferences_registry.manager()
+    f = SimpleUploadedFile(
+        "test_file_24485a80-8db9-4191-ae49-da7fe2013794.txt",
+        "hello world".encode("utf-8"),
+    )
+    try:
+        manager["blog__logo"] = f
+        pickle.dumps(manager["blog__logo"])
+    except Exception:
+        pytest.fail("FilePreference not pickleable")
 
 
 def test_choice_preference(fake_user):


### PR DESCRIPTION
If you have Django 4.2 and latest django-dynamic-preferences==1.15.0 and you try to do something like this:

```
import pickle
from dynamic_preferences.types import  FilePreference
from dynamic_preferences.registries import global_preferences_registry

global_preferences = global_preferences_registry.manager()

@register_preference
class AllCategoryImage(FilePreference):
    name = 'all_category_image'
    verbose_name = 'Header image for catalog'


item = global_preferences['catalog__all_category_image']
pickled_result = pickle.dumps(item)
```

It will result in the error `AttributeError: Can't pickle local object 'PreferenceFieldFile.__init__.<locals>.FakeInstance'`

It worked well with Django 2.x but in newer Django also `field`  and `instance` attributes are added to `__setstate__` -> https://github.com/django/django/commit/f600e3fad6e92d9fe1ad8b351dc8446415f24345