### PR TITLE
add raw prefix to invalid regex

### DIFF
--- a/dynamic_preferences/preferences.py
+++ b/dynamic_preferences/preferences.py
@@ -22,7 +22,7 @@ class InvalidNameError(ValueError):
 
 def check_name(name, obj):
     error = None
-    if not re.match("^\w+$", name):
+    if not re.match(r"^\w+$", name):
         error = "Non-alphanumeric / underscore characters are forbidden in section and preferences names"
     if preferences_settings.SECTION_KEY_SEPARATOR in name:
         error = 'Sequence "{0}" is forbidden in section and preferences name, since it is used to access values via managers'.format(


### PR DESCRIPTION
Without the r prefix, it's an invalid escape sequence. It just blowed up in our CI, and I don't know why it did not blow earlier.
```
  File "/builds/.venv/lib/python3.10/site-packages/dynamic_preferences/preferences.py", line 25
    if not re.match("^\w+$", name):
                    ^^^^^^^
SyntaxError: invalid escape sequence '\w'
```