### PR TITLE
fix(docs): Update Python and django versions in docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python, 2.7, and 3.4. Check
+3. The pull request should work for Python 3.8, 3.9, 3.10 and 3.11. Check
    https://travis-ci.org/agateblue/django-dynamic-preferences/pull_requests
    and make sure that the tests pass for all supported Python versions.
 4. The pull request must target the `develop` branch, since the project relies on `git-flow branching model`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Dynamic-preferences allow you to register settings (a.k.a. preferences) in a dec
 
 With dynamic-preferences, you can update settings on the fly, through django's admin or custom forms, without restarting your application.
 
-The project is tested and work under Python 2.7 and 3.4, 3.5 and 3.6, with django >=1.8.
+The project is tested and work under Python 3.8, 3.9, 3.10 and 3.11 and with django 3.2 and 4.2.
 
 Features
 --------


### PR DESCRIPTION
The index page of the docs still mentioned old versions. Depending on your search engine, this is the first page you encounter.