### PR TITLE
remove six usage

### DIFF
--- a/dynamic_preferences/forms.py
+++ b/dynamic_preferences/forms.py
@@ -1,4 +1,3 @@
-from six import string_types
 from django import forms
 from django.core.exceptions import ValidationError
 from collections import OrderedDict
@@ -85,7 +84,7 @@ def preference_form_builder(form_base_class, preferences=[], **kwargs):
     if len(preferences) > 0:
         # Preferences have been selected explicitly
         for pref in preferences:
-            if isinstance(pref, string_types):
+            if isinstance(pref, str):
                 preferences_obj.append(registry.get(name=pref))
             elif type(pref) == tuple:
                 preferences_obj.append(registry.get(name=pref[0], section=pref[1]))

--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import decimal
 import os
 
@@ -20,7 +19,6 @@ from django.utils.timezone import (
     make_naive,
     get_default_timezone,
 )
-from six import string_types, text_type
 from django.db.models.fields.files import FieldFile
 
 
@@ -62,7 +60,7 @@ class BaseSerializer:
 
     @classmethod
     def to_db(cls, value, **kwargs):
-        return text_type(cls.clean_to_db_value(value))
+        return str(cls.clean_to_db_value(value))
 
     @classmethod
     def clean_to_db_value(cls, value):
@@ -85,7 +83,7 @@ class InstanciatedSerializer(BaseSerializer):
         raise NotImplementedError
 
     def to_db(self, value, **kwargs):
-        return text_type(self.clean_to_db_value(value))
+        return str(self.clean_to_db_value(value))
 
     def clean_to_db_value(self, value):
         return value
@@ -193,7 +191,7 @@ from django.template import defaultfilters
 class StringSerializer(BaseSerializer):
     @classmethod
     def to_db(cls, value, **kwargs):
-        if not isinstance(value, string_types):
+        if not isinstance(value, str):
             raise cls.exception(
                 "Cannot serialize, value {0} is not a string".format(value)
             )

--- a/dynamic_preferences/users/forms.py
+++ b/dynamic_preferences/users/forms.py
@@ -1,4 +1,3 @@
-from six import string_types
 from django import forms
 from django.core.exceptions import ValidationError
 from collections import OrderedDict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-six
 wheel==0.38.1
 persisting_theory==1.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "django>=3.2",
-        "six",
         "persisting_theory==1.0",
     ],
     license="BSD",


### PR DESCRIPTION
Project states it only support Python 3, so these Python 2 crumbs can be cleansed

https://wiki.debian.org/Python3-six-removal