### PR TITLE
Fix conversion of non-integer pk value in ModelSerializer

### DIFF
--- a/dynamic_preferences/serializers.py
+++ b/dynamic_preferences/serializers.py
@@ -232,7 +232,7 @@ class ModelSerializer(InstanciatedSerializer):
         if value is None:
             return
         try:
-            pk = int(value)
+            pk = self.model._meta.pk.to_python(value)
             return self.model.objects.get(pk=pk)
         except:
             raise self.exception("Value {0} cannot be converted to pk".format(value))


### PR DESCRIPTION
Fix #226 

I believe this solves the problem when a pk is not of type int, for example when models have pk of type uuid.