### PR TITLE
Fix #310 The `preference_updated` signal is now triggered when using the REST API

### DIFF
--- a/docs/react_to_updates.rst
+++ b/docs/react_to_updates.rst
@@ -20,7 +20,7 @@ of the signal, which are:
 * ``name`` - the name of the changed preference
 * ``old_value`` - the value of the preference before changing
 * ``new_value`` - the value assigned to the preference after the change
-
+* ``instance`` - the preference Model instance
 An example that just prints a message that the preference was changed is
 below.
 
@@ -28,7 +28,7 @@ below.
 
     # yourapp/util.py
 
-    def notify_on_preference_update(sender, section, name, old_value, new_value, **kwargs):
+    def notify_on_preference_update(sender, section, name, old_value, new_value, instance, **kwargs):
         print("Preference {} in section {} changed from {} to {}".format(
             name, section, old, new))
 

--- a/dynamic_preferences/managers.py
+++ b/dynamic_preferences/managers.py
@@ -173,6 +173,7 @@ class PreferencesManager(Mapping):
                 name=name,
                 old_value=old_value,
                 new_value=value,
+                instance=db_pref
             )
         except self.model.DoesNotExist:
             return self.create_db_pref(section, name, value)

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -192,6 +192,8 @@ def test_get_field_uses_field_kwargs():
 def test_preferences_manager_signal(db):
     global_preferences = global_preferences_registry.manager()
     global_preferences["no_section"] = False
+    pref = global_preferences.get_db_pref(name="no_section", section=None)
+
     receiver = MagicMock()
     preference_updated.connect(receiver)
     global_preferences["no_section"] = True
@@ -203,4 +205,5 @@ def test_preferences_manager_signal(db):
         "name": "no_section",
         "old_value": False,
         "new_value": True,
+        "instance": pref
     }.items() <= call_args.items()


### PR DESCRIPTION
Changes have been made to the `update` method of the PreferenceSerializer to trigger the `preference_updated` signal.

It has been tested for single updates and bulk updates.

I have also added the preference instance to the signal's parameters as it may be needed when you want to retrieve the model bound to a preference, like a workspace, or a user. 

