### PR TITLE
Drop support for python 3.8, django 3.2, run tests on python 3.12, 3.13 and django 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
     steps:
 
       - uses: actions/checkout@v3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,3 +11,4 @@ pytest-django
 pytest-sugar
 django-nose
 ipdb
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=["dynamic_preferences"],
     include_package_data=True,
     install_requires=[
-        "django>=3.2",
+        "django>=4.2",
         "persisting_theory==1.0",
     ],
     license="BSD",

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 
 [tox]
 envlist =
-    {py37,py38,py39,py310}-django-32
-    {py38,py39,py310,py311}-django-42
-    {py311}-django-main
+    {py38,py39,py310,py311,py312}-django-42
+    {py310,py311,py312,py313}-django-51
+    {py313}-django-main
 
 
 [testenv]
@@ -16,19 +16,20 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands = pytest --cov=dynamic_preferences {posargs}
 deps =
-    django-{32,42,main}: djangorestframework>=3.13,<4
-    django-32: Django>=3.2,<3.3
+    django-{42,51,main}: djangorestframework>=3.13,<4
     django-42: Django>=4.2,<5.0
+    django-51: Django>=5.1,<6.0
     django-main: https://github.com/django/django/archive/main.tar.gz
     -r{toxinidir}/requirements-test.txt
 
 
 basepython =
+    py313: python3.13
+    py312: python3.12
     py311: python3.11
     py310: python3.10
     py39: python3.9
     py38: python3.8
-    py37: python3.7
 
-[testenv:py311-django-main]
+[testenv:py313-django-main]
 ignore_outcome = true


### PR DESCRIPTION
No tests broke with the new versions of Python/django, but it's still good to ensure the tests run in CI ;)